### PR TITLE
exchanged out apostrophes for the unicode escape sequence

### DIFF
--- a/inertia/inertia.py
+++ b/inertia/inertia.py
@@ -397,7 +397,7 @@ class Inertia:
         # Fallback to server-side template rendering
         page_json = json.dumps(
             json.dumps(self._get_page_data(), cls=self._config.json_encoder)
-        )
+        ).replace("'", r"\u0027")
         return self._config.templates.TemplateResponse(
             name=self._config.root_template_filename,
             request=self._request,

--- a/inertia/tests/test_apostrophe_in_prop_values_work.py
+++ b/inertia/tests/test_apostrophe_in_prop_values_work.py
@@ -1,0 +1,42 @@
+from fastapi import FastAPI, Depends
+from typing import Annotated
+
+from starlette.testclient import TestClient
+
+from inertia import Inertia, inertia_dependency_factory, InertiaResponse, InertiaConfig
+
+from .utils import assert_response_content, templates
+
+app = FastAPI()
+
+InertiaDep = Annotated[
+    Inertia, Depends(inertia_dependency_factory(InertiaConfig(templates=templates)))
+]
+
+PROPS = {
+    "normal": "Quick fox jumped over lazy dog",
+    "apostrophe": "Q'uick fox jump'ed o'ver lazy dog",
+}
+
+EXPECTED_PROPS = {**PROPS}
+
+COMPONENT = "IndexPage"
+
+
+@app.get("/", response_model=None)
+async def index(inertia: InertiaDep) -> InertiaResponse:
+    return await inertia.render(COMPONENT, PROPS)
+
+
+def test_first_request_returns_html() -> None:
+    with TestClient(app) as client:
+        response = client.get("/")
+        assert response.status_code == 200
+        assert response.headers.get("content-type").split(";")[0] == "text/html"
+        expected_url = str(client.base_url) + "/"
+        assert_response_content(
+            response,
+            expected_component=COMPONENT,
+            expected_props=EXPECTED_PROPS,
+            expected_url=expected_url,
+        )


### PR DESCRIPTION
Addresses the issue present in #30, where apostrophes stop the page from loading. 