### PR TITLE
Fix: properly escape special characters in JSON payload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 1.0.3 - 2024-10-04
-- Chore: unpin fastapi and jinja versions to allow install with latest versions -- @holandes22
+## [1.0.4] - 2025-02-23
 
+- Fix: safely escape special characters in JSON payload to avoid ([#30](https://github.com/hxjo/fastapi-inertia/issues/30)) -- @mofman
+
+## [1.0.3] - 2024-10-04
+
+- Chore: unpin fastapi and jinja versions to allow install with latest versions -- @holandes22
 
 ## [1.0.2] - 2024-07-19
 

--- a/inertia/inertia.py
+++ b/inertia/inertia.py
@@ -18,7 +18,7 @@ from typing import (
 import json
 from pydantic import BaseModel
 from starlette.responses import RedirectResponse
-
+from jinja2.utils import htmlsafe_json_dumps
 
 from .templating import InertiaExtension
 from .config import InertiaConfig
@@ -395,9 +395,8 @@ class Inertia:
                 )
 
         # Fallback to server-side template rendering
-        page_json = json.dumps(
-            json.dumps(self._get_page_data(), cls=self._config.json_encoder)
-        )
+        json_string = json.dumps(self._get_page_data(), cls=self._config.json_encoder)
+        page_json = htmlsafe_json_dumps(json_string)
         return self._config.templates.TemplateResponse(
             name=self._config.root_template_filename,
             request=self._request,

--- a/inertia/tests/test_special_chars_in_prop_values_are_safely_escaped.py
+++ b/inertia/tests/test_special_chars_in_prop_values_are_safely_escaped.py
@@ -50,3 +50,4 @@ def test_special_chars_are_escaped() -> None:
             expected_props=EXPECTED_PROPS,
             expected_url=expected_url,
         )
+

--- a/inertia/tests/test_special_chars_in_prop_values_are_safely_escaped.py
+++ b/inertia/tests/test_special_chars_in_prop_values_are_safely_escaped.py
@@ -25,7 +25,7 @@ COMPONENT = "IndexPage"
 async def index(inertia: InertiaDep) -> InertiaResponse:
     return await inertia.render(COMPONENT, PROPS)
 
-def test_first_request_returns_html() -> None:
+def test_special_chars_are_escaped() -> None:
     with TestClient(app) as client:
         response = client.get("/")
         

--- a/inertia/tests/test_special_chars_in_prop_values_are_safely_escaped.py
+++ b/inertia/tests/test_special_chars_in_prop_values_are_safely_escaped.py
@@ -1,0 +1,52 @@
+import re
+from fastapi import FastAPI, Depends
+from typing import Annotated
+from starlette.testclient import TestClient
+
+from inertia import Inertia, inertia_dependency_factory, InertiaResponse, InertiaConfig
+
+from .utils import assert_response_content, templates
+
+app = FastAPI()
+
+InertiaDep = Annotated[
+    Inertia, Depends(inertia_dependency_factory(InertiaConfig(templates=templates)))
+]
+
+# Include a property with special characters.
+PROPS = {
+    "special": "<>&'"
+}
+
+EXPECTED_PROPS = {**PROPS}
+COMPONENT = "IndexPage"
+
+@app.get("/", response_model=None)
+async def index(inertia: InertiaDep) -> InertiaResponse:
+    return await inertia.render(COMPONENT, PROPS)
+
+def test_first_request_returns_html() -> None:
+    with TestClient(app) as client:
+        response = client.get("/")
+        
+        assert response.status_code == 200
+        assert response.headers.get("content-type").split(";")[0] == "text/html"
+
+        html_output = response.text
+
+        match = re.search(r'<div\s+id=["\']app["\'][^>]*\sdata-page=(["\'])(.*?)\1', html_output)
+        assert match, "Could not find the div with id 'app' and a data-page attribute."
+        data_page_value = match.group(2)
+
+        assert "<" not in data_page_value, "Expected '<' to be escaped as \\u003c in data-page."
+        assert ">" not in data_page_value, "Expected '>' to be escaped as \\u003e in data-page."
+        assert "&" not in data_page_value, "Expected '&' to be escaped as \\u0026 in data-page."
+        assert "'" not in data_page_value, "Expected '<' to be escaped as \\u0027 in data-page."
+
+        expected_url = str(client.base_url) + "/"
+        assert_response_content(
+            response,
+            expected_component=COMPONENT,
+            expected_props=EXPECTED_PROPS,
+            expected_url=expected_url,
+        )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "fastapi-inertia"
-version = "1.0.3"
+version = "1.0.4"
 description = "An implementation of the Inertia protocol for FastAPI."
 authors = ["Hugo Mortreux <70602545+hxjo@users.noreply.github.com>"]
 license = "MIT"


### PR DESCRIPTION
Instead of double encoding with json.dumps, this commit imports htmlsafe_json_dumps from jinja2.utils and applies it to the JSON string, ensuring proper escaping and safe rendering.

https://github.com/pallets/jinja/blob/6aeab5d1da0bc0793406d7b402693e779b6cca7a/src/jinja2/utils.py#L668